### PR TITLE
Add support for multi-action statements

### DIFF
--- a/myiam-api/myiam_api/data/policies.yaml
+++ b/myiam-api/myiam_api/data/policies.yaml
@@ -4,3 +4,11 @@
       actions: "*"
       resources: "*"
       effect: allow
+- policy_name: UserReadAccess
+  statements:
+    - sid: AllowReadUsers
+      actions:
+        - myiam:DescribeUser
+        - myiam:ListUsers
+      resources: "*"
+      effect: allow

--- a/myiam-api/myiam_api/data/roles.yaml
+++ b/myiam-api/myiam_api/data/roles.yaml
@@ -1,3 +1,6 @@
 - role_name: SystemAdministrator
   policy_names:
     - FullRootAccess
+- role_name: IdentityAdministrator
+  policy_names:
+    - UserReadAccess

--- a/myiam-cdk/resources/lambdas/ddb_stream_handler/handler.py
+++ b/myiam-cdk/resources/lambdas/ddb_stream_handler/handler.py
@@ -1,7 +1,27 @@
+import os
 import json
 import boto3
 import logging
 import myiam
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+
+SENTRY_DSN = os.environ.get("SENTRY_DSN") or ""
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT") or ""
+
+
+sentry_sdk.init(
+    SENTRY_DSN,
+    SENTRY_ENVIRONMENT,
+    traces_sample_rate=1.0,
+    integrations=[
+        LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+        AwsLambdaIntegration(timeout_warning=True),
+    ]
+)
+
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/myiam-cdk/resources/lambdas/ddb_stream_handler/handler.py
+++ b/myiam-cdk/resources/lambdas/ddb_stream_handler/handler.py
@@ -90,14 +90,20 @@ def _should_cleanup_policy_statement_rules(record):
 
 def _derive_policy_statement_rules(record):
 
+    resources = [record["dynamodb"]["NewImage"]["resources"]]
+    resources = [resources["S"]] if resources.get("S") else [_["S"] for _ in resources["L"]]
+
+    actions = [record["dynamodb"]["NewImage"]["actions"]]
+    actions = [actions["S"]] if actions.get("S") else [_["S"] for _ in actions["L"]]
+
     # Convert statement into rules
     rules = myiam.convert_policy_statement_into_rules(
         {
             "pk": record["dynamodb"]["NewImage"]["pk"]["S"],
             "sk": record["dynamodb"]["NewImage"]["sk"]["S"],
             "effect": record["dynamodb"]["NewImage"]["effect"]["S"],
-            "resources": [record["dynamodb"]["NewImage"]["resources"]["S"]],
-            "actions": [record["dynamodb"]["NewImage"]["actions"]["S"]],
+            "resources": resources,
+            "actions": actions,
             "statement_signatures": {
                 action_name: signature["S"] for action_name, signature in
                 record["dynamodb"]["NewImage"]["statement_signatures"]["M"].items()

--- a/myiam-py/tests/conftest.py
+++ b/myiam-py/tests/conftest.py
@@ -42,3 +42,18 @@ def generic_policy():
             }
         ],
     )
+
+
+@pytest.fixture
+def multiaction_policy():
+    return dict(
+        schema_version="1.0",
+        statements=[
+            {
+                "sid": "AllowCollaboration",
+                "effect": "allow",
+                "resources": "databases/sales",
+                "actions": ["WriteData", "QueryData"],
+            }
+        ],
+    )

--- a/myiam-py/tests/test_api_policies.py
+++ b/myiam-py/tests/test_api_policies.py
@@ -14,6 +14,12 @@ def test_create_policy(ddbt, generic_policy):
     print(policys)
 
 
+def test_create_multiaction_policy(ddbt, multiaction_policy):
+    create_policy(ddbt, policy_name="SalesDataReadWrite", **multiaction_policy)
+    policys = list_policies(ddbt)
+    print(policys)
+
+
 def test_describe_policy(ddbt, generic_policy):
     create_policy(ddbt, policy_name="SalesDataReadOnly", **generic_policy)
     policy = describe_policy(ddbt, policy_name="SalesDataReadOnly")


### PR DESCRIPTION
## Problem

Policies are currently limited to single-action statements.

## Solution

Allow policies to declare multiple actions per statement.

Example:

```
{"effect": "allow", "actions": ["app:Watch", "app:Start"]}
```
