### PR TITLE
Improve sentry and aws x-ray support

### DIFF
--- a/myiam-cdk/lib/myiam-cdk-stack.ts
+++ b/myiam-cdk/lib/myiam-cdk-stack.ts
@@ -83,7 +83,12 @@ export class MyIamCdkStack extends cdk.Stack {
       code: lambda.Code.fromAsset("resources/lambdas/api"),
       handler: "handler.handle",
       runtime: lambda.Runtime.PYTHON_3_8,
-      layers: [apiLayer],
+      tracing: lambda.Tracing.ACTIVE,
+      layers: [apiLayer, sentryLayer],
+      environment: {
+        SENTRY_DSN: sentryDsn.valueAsString,
+        SENTRY_ENVIRONMENT: sentryEnvironment.valueAsString,
+      },
       initialPolicy: [
         new iam.PolicyStatement({
           sid: "AllowLambdaToQueryDynamoDbTable",
@@ -103,9 +108,14 @@ export class MyIamCdkStack extends cdk.Stack {
     const authorizerLambda = new lambda.Function(this, "MyIamApiAuthorizerLambda", {
       functionName: "MyIamApiAuthorizerLambda",
       runtime: lambda.Runtime.PYTHON_3_8,
-      layers: [authorizerLayer],
+      tracing: lambda.Tracing.ACTIVE,
+      layers: [authorizerLayer, sentryLayer],
       code: lambda.Code.fromAsset('resources/lambdas/authorizer'),
       handler: "handler.handle",
+      environment: {
+        SENTRY_DSN: sentryDsn.valueAsString,
+        SENTRY_ENVIRONMENT: sentryEnvironment.valueAsString,
+      },
       initialPolicy: [
         new iam.PolicyStatement({
           sid: "AllowLambdaToQueryDynamoDbTable",
@@ -125,6 +135,9 @@ export class MyIamCdkStack extends cdk.Stack {
 
     const api = new apig.LambdaRestApi(this, "MyIamRestApi", {
       handler: apiHandler,
+      deployOptions: {
+        tracingEnabled: true
+      },
       defaultMethodOptions: {
         authorizationType: apig.AuthorizationType.CUSTOM,
         authorizer

--- a/myiam-cdk/resources/lambdas/api/handler.py
+++ b/myiam-cdk/resources/lambdas/api/handler.py
@@ -1,5 +1,17 @@
+import logging
 from apig_wsgi import make_lambda_handler
 from myiam_api import app
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
+
+sentry_sdk.init(
+    traces_sample_rate=1.0,
+    integrations=[
+        LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+        AwsLambdaIntegration(timeout_warning=True),
+    ]
+)
 
 handle = make_lambda_handler(app)

--- a/myiam-cdk/resources/lambdas/ddb_stream_handler/handler.py
+++ b/myiam-cdk/resources/lambdas/ddb_stream_handler/handler.py
@@ -1,4 +1,3 @@
-import os
 import json
 import boto3
 import logging
@@ -8,20 +7,13 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 
-SENTRY_DSN = os.environ.get("SENTRY_DSN") or ""
-SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT") or ""
-
-
 sentry_sdk.init(
-    SENTRY_DSN,
-    SENTRY_ENVIRONMENT,
-    traces_sample_rate=1.0,
+    traces_sample_rate=0.0,
     integrations=[
         LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
         AwsLambdaIntegration(timeout_warning=True),
     ]
 )
-
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Problem

Inspecting performance is not as trivial.

## Solution

Improve segment monitoring using Sentry.
Introduce AWS X-Ray support. 

Tracing may be fully migrated to X-Ray and disabled in Sentry soon.
